### PR TITLE
Boolean support + logic operators

### DIFF
--- a/src/compiler/architecture.rs
+++ b/src/compiler/architecture.rs
@@ -119,6 +119,17 @@ impl Arch {
         }
     }
 
+    pub fn get_mov_boolean_instr(&self, value: bool) -> String {
+        match self {
+            Arch::X86_64 => {
+                if value { "mov rax, 1".to_string() } else { "mov rax, 0".to_string() }
+            },
+            Arch::AArch64 => {
+                if value { "mov x0, 1".to_string() } else { "mov x0, 0".to_string() }
+            },
+        }
+    }
+
     pub fn get_load_variable_instr(&self, offset: usize) -> String {
         match self {
             Arch::X86_64 => format!("mov rax, [rsp + {}]", offset * 8),

--- a/src/compiler/arithmetic_instructions.rs
+++ b/src/compiler/arithmetic_instructions.rs
@@ -46,7 +46,15 @@ impl ArithmeticInstructions {
             ("Exponentiation".to_string(),
             operation(exp_reg_lhs, exp_reg_rhs, exp_result_reg, vec![TARGET_ARCH.get_exponentiation_instr()])),
             ("Modulo".to_string(),
-            operation(arith_reg_lhs, arith_reg_rhs, modulo_result_reg, vec![TARGET_ARCH.get_modulo_instr()]))
+            operation(arith_reg_lhs, arith_reg_rhs, modulo_result_reg, vec![TARGET_ARCH.get_modulo_instr()])),
+            ("And".to_string(),
+            operation(arith_reg_lhs, arith_reg_rhs, arith_result_reg, vec![TARGET_ARCH.get_and_instr()])),
+            ("Or".to_string(),
+            operation(arith_reg_lhs, arith_reg_rhs, arith_result_reg, vec![TARGET_ARCH.get_or_instr()])),
+            ("Xor".to_string(),
+            operation(arith_reg_lhs, arith_reg_rhs, arith_result_reg, vec![TARGET_ARCH.get_xor_instr()])),
+            ("Not".to_string(),
+            operation(arith_reg_lhs, arith_reg_rhs, arith_result_reg, vec![TARGET_ARCH.get_not_instr()])),
             ]
         );
         ArithmeticInstructions{instrs: map}

--- a/src/compiler/logger.rs
+++ b/src/compiler/logger.rs
@@ -30,7 +30,9 @@ pub enum ParserErrorType{
     ErrExitClosedParenthesisMissing,
     ErrUnexpectedToken,
     ErrExpressionOpenParenthesisMissing,
-    ErrExpressionClosedParenthesisMissing
+    ErrExpressionClosedParenthesisMissing,
+    ErrMissingOperand,
+    ErrTypeMismatch,
 }
 
 impl ParserErrorType {
@@ -42,6 +44,8 @@ impl ParserErrorType {
             ParserErrorType::ErrUnexpectedToken => "Unexpected character sequence found here.",
             ParserErrorType::ErrExpressionOpenParenthesisMissing => "Mismatched Parenthesis: ( is missing",
             ParserErrorType::ErrExpressionClosedParenthesisMissing => "Mismatched Parenthesis: ) is missing",
+            ParserErrorType::ErrMissingOperand => "Missing operand for operator.",
+            ParserErrorType::ErrTypeMismatch => "Type mismatch in expression.",
         }
     }
 }

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -88,3 +88,48 @@ fn test_wrong_variable_assignment(){
         assert!(result.is_none(), "For input `{bad_var_input}`, the parser should fail but succeeded with: {:?}", result);
     }
 }
+
+#[test]
+fn test_missing_operand_logical() {
+    let input = "x = a &&";
+    let mut parser = utility_create_parser(input);
+    let result = parser.parse();
+    assert!(result.is_none(), "Parser should fail for missing operand in logical expression 'x = a &&'");
+}
+
+#[test]
+fn test_missing_operand_unary() {
+    let input = "x = !!";
+    let mut parser = utility_create_parser(input);
+    let result = parser.parse();
+    assert!(result.is_none(), "Parser should fail for missing operand in unary expression 'x = !!'");
+}
+
+#[test]
+fn test_boolean_expression_parsing() {
+    let input = "x = true";
+    let mut parser = utility_create_parser(input);
+    let prog = parser.parse().expect("Parser should succeed for 'x = true'");
+    let stmts = prog.get_stmts();
+    assert_eq!(stmts.len(), 1, "Expected one statement");
+
+    let ast_string = format!("{}", stmts[0]);
+    assert_eq!(ast_string, "x = true", "AST should correctly represent the boolean expression");
+}
+
+#[test]
+fn test_valid_boolean_logical_expression() {
+    let input = "x = true && false";
+    let mut parser = utility_create_parser(input);
+    let prog = parser.parse().expect("Parser should succeed for a boolean logical expression");
+    let ast_string = format!("{}", prog.get_stmts()[0]);
+    assert_eq!(ast_string, "x = true && false", "AST should correctly represent the boolean logical expression");
+}
+
+#[test]
+fn test_invalid_logical_expression_non_boolean_operand() {
+    let input = "x = 1 && true";
+    let mut parser = utility_create_parser(input);
+    let result = parser.parse();
+    assert!(result.is_none(), "Parser should fail when non-boolean operand is used with a logical operator");
+}

--- a/tests/tokenizer_test.rs
+++ b/tests/tokenizer_test.rs
@@ -133,3 +133,80 @@ fn test_operators(){
     assert_eq!(tokenizer.get_tokens(), expected_token);
 }
 
+#[test]
+fn test_logical_operators() {
+    let mut tokenizer = TOKENIZER.lock().unwrap();
+    tokenizer.tokenize("&&||!!^|");
+
+    let expected_tokens = vec![
+        Token::Operator(Operator::And { span: (0, (0, 1)) }),
+        Token::Operator(Operator::Or  { span: (0, (2, 3)) }),
+        Token::Operator(Operator::Not { span: (0, (4, 5)) }),
+        Token::Operator(Operator::Xor { span: (0, (6, 7)) }),
+    ];
+    assert_eq!(tokenizer.get_tokens(), expected_tokens);
+}
+
+#[test]
+fn test_logical_operators_with_spacing() {
+    let mut tokenizer = TOKENIZER.lock().unwrap();
+    tokenizer.tokenize("x && y || !! z ^| w");
+
+    let expected_tokens = vec![
+        Token::ID { name: "x".to_string(), span: (0, (0, 0)) },
+        Token::WhiteSpace { span: (0, (1, 1)) },
+        Token::Operator(Operator::And { span: (0, (2, 3)) }),
+        Token::WhiteSpace { span: (0, (4, 4)) },
+        Token::ID { name: "y".to_string(), span: (0, (5, 5)) },
+        Token::WhiteSpace { span: (0, (6, 6)) },
+        Token::Operator(Operator::Or { span: (0, (7, 8)) }),
+        Token::WhiteSpace { span: (0, (9, 9)) },
+        Token::Operator(Operator::Not { span: (0, (10, 11)) }),
+        Token::WhiteSpace { span: (0, (12, 12)) },
+        Token::ID { name: "z".to_string(), span: (0, (13, 13)) },
+        Token::WhiteSpace { span: (0, (14, 14)) },
+        Token::Operator(Operator::Xor { span: (0, (15, 16)) }),
+        Token::WhiteSpace { span: (0, (17, 17)) },
+        Token::ID { name: "w".to_string(), span: (0, (18, 18)) },
+    ];
+    assert_eq!(tokenizer.get_tokens(), expected_tokens);
+}
+
+#[test]
+fn test_boolean_tokens() {
+    let mut tokenizer = TOKENIZER.lock().unwrap();
+    tokenizer.tokenize("true false");
+
+    let expected_tokens = vec![
+        Token::Boolean { value: true, span: (0, (0, 3)) },
+        Token::WhiteSpace { span: (0, (4, 4)) },
+        Token::Boolean { value: false, span: (0, (5, 9)) },
+    ];
+    assert_eq!(tokenizer.get_tokens(), expected_tokens);
+}
+
+#[test]
+fn test_logical_operators_multiline() {
+    let mut tokenizer = TOKENIZER.lock().unwrap();
+    tokenizer.tokenize("x && y\n|| !! z\n^| w");
+
+    let expected_tokens = vec![
+        Token::ID { name: "x".to_string(), span: (0, (0, 0)) },
+        Token::WhiteSpace { span: (0, (1, 1)) },
+        Token::Operator(Operator::And { span: (0, (2, 3)) }),
+        Token::WhiteSpace { span: (0, (4, 4)) },
+        Token::ID { name: "y".to_string(), span: (0, (5, 5)) },
+        Token::NewLine { span: (0, (6, 6)) },
+        Token::Operator(Operator::Or { span: (1, (0, 1)) }),
+        Token::WhiteSpace { span: (1, (2, 2)) },
+        Token::Operator(Operator::Not { span: (1, (3, 4)) }),
+        Token::WhiteSpace { span: (1, (5, 5)) },
+        Token::ID { name: "z".to_string(), span: (1, (6, 6)) },
+        Token::NewLine { span: (1, (7, 7)) },
+        Token::Operator(Operator::Xor { span: (2, (0, 1)) }),
+        Token::WhiteSpace { span: (2, (2, 2)) },
+        Token::ID { name: "w".to_string(), span: (2, (3, 3)) },
+    ];
+
+    assert_eq!(tokenizer.get_tokens(), expected_tokens);
+}


### PR DESCRIPTION
- Includes changes from: [pull/15](https://github.com/bmd2001/ProgrammingLanguage/pull/15). Previously, numbers were converted to their binary values for logical operators, but now only boolean values are accepted.

So overall this PR includes:
- [x] Arithmetic Instructions update (Adding and/or/xor/not).
- [x] Logger Modifications to include: ErrMissingOperand, ErrTypeMismatch in ParserErrorType.
- [x] Changes to the generator (mapping true to 1 and false to 0 and type checking in logical operands).
- [x] Modified parser to handle boolean expressions.
- [x] Added some tests for parsing, logical expressions, error cases and to ensure true and false are tokenised as boolean tokens.